### PR TITLE
Move the epel-testing repos to another file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ name                                                                          | 
 ------------------------------------------------------------------------------|-----------------------------------------------
 [`couchbase`](http://www.couchbase.com/)                                      | `couchbase`
 [`endpoint`](https://packages.endpoint.com/)                                  | `endpoint`
-[`epel`](https://fedoraproject.org/wiki/EPEL)                                 | `epel` `epel-testing`
+[`epel`](https://fedoraproject.org/wiki/EPEL)                                 | `epel`
+[`epel-testing`](https://fedoraproject.org/wiki/EPEL/testing)                 | `epel-testing`
 [`epel-yum-rawhide`](https://repos.fedorapeople.org/repos/james/yum-rawhide/) | `epel-yum-rawhide`
 [`hortonworks`](http://hortonworks.com/)                                      | `ambari-1x` `HDP-1.3.0.0` `HDP-UTILS-1.1.0.15`
 [`ius`](https://iuscommunity.org/pages/About.html)                            | `ius` `ius-testing` `ius-dev` `ius-archive`
@@ -69,7 +70,8 @@ name                                                                          | 
 ------------------------------------------------------------------------------|-----------------------------------------------
 [`couchbase`](http://www.couchbase.com/)                                      | `couchbase`
 [`endpoint`](https://packages.endpoint.com/)                                  | `endpoint`
-[`epel`](https://fedoraproject.org/wiki/EPEL)                                 | `epel` `epel-testing`
+[`epel`](https://fedoraproject.org/wiki/EPEL)                                 | `epel`
+[`epel-testing`](https://fedoraproject.org/wiki/EPEL/testing)                 | `epel-testing`
 [`epel-yum-rawhide`](https://repos.fedorapeople.org/repos/james/yum-rawhide/) | `epel-yum-rawhide`
 [`hortonworks`](http://hortonworks.com/)                                      | `ambari-1x` `HDP-1.3.0.0` `HDP-UTILS-1.1.0.15`
 [`ius`](https://iuscommunity.org/pages/About.html)                            | `ius` `ius-testing` `ius-dev` `ius-archive`

--- a/files/centos6/epel-testing.repo
+++ b/files/centos6/epel-testing.repo
@@ -1,0 +1,26 @@
+[epel-testing]
+name=Extra Packages for Enterprise Linux 6 - Testing - $basearch
+#baseurl=http://download.fedoraproject.org/pub/epel/testing/6/$basearch
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-epel6&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
+
+[epel-testing-debuginfo]
+name=Extra Packages for Enterprise Linux 6 - Testing - $basearch - Debug
+#baseurl=http://download.fedoraproject.org/pub/epel/testing/6/$basearch/debug
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel6&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
+gpgcheck=1
+
+[epel-testing-source]
+name=Extra Packages for Enterprise Linux 6 - Testing - $basearch - Source
+#baseurl=http://download.fedoraproject.org/pub/epel/testing/6/SRPMS
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel6&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
+gpgcheck=1

--- a/files/centos6/epel.repo
+++ b/files/centos6/epel.repo
@@ -24,30 +24,3 @@ failovermethod=priority
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
 gpgcheck=1
-
-[epel-testing]
-name=Extra Packages for Enterprise Linux 6 - Testing - $basearch
-#baseurl=http://download.fedoraproject.org/pub/epel/testing/6/$basearch
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-epel6&arch=$basearch
-failovermethod=priority
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
-
-[epel-testing-debuginfo]
-name=Extra Packages for Enterprise Linux 6 - Testing - $basearch - Debug
-#baseurl=http://download.fedoraproject.org/pub/epel/testing/6/$basearch/debug
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel6&arch=$basearch
-failovermethod=priority
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
-gpgcheck=1
-
-[epel-testing-source]
-name=Extra Packages for Enterprise Linux 6 - Testing - $basearch - Source
-#baseurl=http://download.fedoraproject.org/pub/epel/testing/6/SRPMS
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel6&arch=$basearch
-failovermethod=priority
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
-gpgcheck=1

--- a/files/centos7/epel-testing.repo
+++ b/files/centos7/epel-testing.repo
@@ -1,0 +1,26 @@
+[epel-testing]
+name=Extra Packages for Enterprise Linux 7 - Testing - $basearch
+#baseurl=http://download.fedoraproject.org/pub/epel/testing/7/$basearch
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-epel7&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+
+[epel-testing-debuginfo]
+name=Extra Packages for Enterprise Linux 7 - Testing - $basearch - Debug
+#baseurl=http://download.fedoraproject.org/pub/epel/testing/7/$basearch/debug
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel7&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+gpgcheck=1
+
+[epel-testing-source]
+name=Extra Packages for Enterprise Linux 7 - Testing - $basearch - Source
+#baseurl=http://download.fedoraproject.org/pub/epel/testing/7/SRPMS
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel7&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+gpgcheck=1

--- a/files/centos7/epel.repo
+++ b/files/centos7/epel.repo
@@ -24,30 +24,3 @@ failovermethod=priority
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 gpgcheck=1
-
-[epel-testing]
-name=Extra Packages for Enterprise Linux 7 - Testing - $basearch
-#baseurl=http://download.fedoraproject.org/pub/epel/testing/7/$basearch
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-epel7&arch=$basearch
-failovermethod=priority
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
-
-[epel-testing-debuginfo]
-name=Extra Packages for Enterprise Linux 7 - Testing - $basearch - Debug
-#baseurl=http://download.fedoraproject.org/pub/epel/testing/7/$basearch/debug
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel7&arch=$basearch
-failovermethod=priority
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
-gpgcheck=1
-
-[epel-testing-source]
-name=Extra Packages for Enterprise Linux 7 - Testing - $basearch - Source
-#baseurl=http://download.fedoraproject.org/pub/epel/testing/7/SRPMS
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel7&arch=$basearch
-failovermethod=priority
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
-gpgcheck=1


### PR DESCRIPTION
CentOS 7 seems to come by default with an `epel-testing.repo` file.
Our `epel.repo` conflicts with it.

```
Repository epel-testing is listed more than once in the configuration
Repository epel-testing-debuginfo is listed more than once in the configuration
Repository epel-testing-source is listed more than once in the configuration
```

This moves all the epel-testing repos to another file and disables them.
