### PR TITLE
Elasticsearch 2.x repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Supported Repositories
 name                                                                          | provides
 ------------------------------------------------------------------------------|-----------------------------------------------
 [`couchbase`](http://www.couchbase.com/)                                      | `couchbase`
-[`elasticsearch`](https://www.elastic.co/products/elasticsearch)              | `elasticsearch`
+[`elasticsearch`](https://www.elastic.co/products/elasticsearch)              | `elasticsearch-2.x`
 [`endpoint`](https://packages.endpoint.com/)                                  | `endpoint`
 [`epel`](https://fedoraproject.org/wiki/EPEL)                                 | `epel`
 [`epel-testing`](https://fedoraproject.org/wiki/EPEL/testing)                 | `epel-testing`
@@ -95,7 +95,7 @@ become available.
 name                                                                          | provides
 ------------------------------------------------------------------------------|-----------------------------------------------
 [`couchbase`](http://www.couchbase.com/)                                      | `couchbase`
-[`elasticsearch`](https://www.elastic.co/products/elasticsearch)              | `elasticsearch`
+[`elasticsearch`](https://www.elastic.co/products/elasticsearch)              | `elasticsearch-2.x`
 [`endpoint`](https://packages.endpoint.com/)                                  | `endpoint`
 [`epel`](https://fedoraproject.org/wiki/EPEL)                                 | `epel`
 [`epel-testing`](https://fedoraproject.org/wiki/EPEL/testing)                 | `epel-testing`
@@ -130,7 +130,7 @@ name                                                                          | 
 ------------------------------------------------------------------------------|-----------------------------------------------
 [`backports`](https://packages.debian.org/wheezy-backports/)                  | `backports`
 [`dotdeb`](https://www.dotdeb.org)                                            | `dotdeb`
-[`elasticsearch`](https://www.elastic.co/products/elasticsearch)              | `elasticsearch`
+[`elasticsearch`](https://www.elastic.co/products/elasticsearch)              | `elasticsearch-2.x`
 [`jenkins`](http://jenkins-ci.org/)                                           | `jenkins`
 [`mongodb`](http://mongodb.org/)                                              | `mongodb`
 [`mysql`](https://www.mysql.fr/products/community/)                           | `mysql56-community`
@@ -147,7 +147,7 @@ name                                                                          | 
 ------------------------------------------------------------------------------|-----------------------------------------------
 [`backports`](https://packages.debian.org/jessie-backports/)                  | `backports`
 [`dotdeb`](https://www.dotdeb.org)                                            | `dotdeb`
-[`elasticsearch`](https://www.elastic.co/products/elasticsearch)              | `elasticsearch`
+[`elasticsearch`](https://www.elastic.co/products/elasticsearch)              | `elasticsearch-2.x`
 [`jenkins`](http://jenkins-ci.org/)                                           | `jenkins`
 [`mongodb`](http://mongodb.org/)                                              | `mongodb`
 [`mysql`](https://www.mysql.fr/products/community/)                           | `mysql56-community`

--- a/templates/centos6/elasticsearch.repo.j2
+++ b/templates/centos6/elasticsearch.repo.j2
@@ -1,6 +1,6 @@
 [elasticsearch]
-name=Elasticsearch repository for 1.6.x packages
-baseurl=http://packages.elastic.co/elasticsearch/1.6/centos
+name=Elasticsearch repository for 2.x packages
+baseurl=http://packages.elastic.co/elasticsearch/2.x/centos
 gpgcheck=1
 gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
 enabled={{item['enabled']|default(0)}}

--- a/templates/centos7/elasticsearch.repo.j2
+++ b/templates/centos7/elasticsearch.repo.j2
@@ -1,6 +1,6 @@
 [elasticsearch]
-name=Elasticsearch repository for 1.6.x packages
-baseurl=http://packages.elastic.co/elasticsearch/1.6/centos
+name=Elasticsearch repository for 2.x packages
+baseurl=http://packages.elastic.co/elasticsearch/2.x/centos
 gpgcheck=1
 gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
 enabled={{item['enabled']|default(0)}}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,9 @@ repository_list:
     wheezy:
       url: "http://ftp.jp.debian.org/debian"
       pool: "{{ ansible_distribution_release }}-backports main"
+    jessie:
+      url: "http://ftp.jp.debian.org/debian"
+      pool: "{{ ansible_distribution_release }}-backports main"
   couchbase:
     centos6:
       repo: couchbase.repo
@@ -17,7 +20,7 @@ repository_list:
       key: "dotdeb.gpg"
       url: "http://packages.dotdeb.org"
       pool: "{{ ansible_distribution_release }} all"
-  elasticsearch:
+  elasticsearch-2.x:
     centos6:
       repo: elasticsearch.repo
       key: GPG-KEY-elasticsearch
@@ -26,11 +29,11 @@ repository_list:
       key: GPG-KEY-elasticsearch
     wheezy:
       key: "GPG-KEY-elasticsearch"
-      url: "http://packages.elastic.co/elasticsearch/1.7/debian"
+      url: "http://packages.elasticsearch.org/elasticsearch/2.x/debian"
       pool: "stable main"
     jessie:
       key: "GPG-KEY-elasticsearch"
-      url: "http://packages.elastic.co/elasticsearch/1.7/debian"
+      url: "http://packages.elasticsearch.org/elasticsearch/2.x/debian"
       pool: "stable main"
   endpoint:
     centos6:


### PR DESCRIPTION
This PR adds Elasticsearch 2.x repos for CentOS 6/7 and Debian Wheezy (7) and Jessie (8).
Elasticsearch versions under 2.x is not supported.
