### PR TITLE
Add the Percona repo for CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ name                                                                          | 
 [`mongodb`](http://mongodb.org/)                                              | `mongodb`
 [`mysql`](https://www.mysql.fr/products/community/)                           | `mysql56-community` `mysql-connectors-community` `mysql-tools-community` 
 [`nginx`](http://nginx.org/)                                                  | `nginx`
+[`percona`](https://www.percona.com)                                          | `percona-release-x86_64`
 [`postgresql 9.0`](http://yum.postgresql.org/repopackages.php)                | `pgdg90`
 [`postgresql 9.1`](http://yum.postgresql.org/repopackages.php)                | `pgdg91`
 [`postgresql 9.2`](http://yum.postgresql.org/repopackages.php)                | `pgdg92`
@@ -106,6 +107,7 @@ name                                                                          | 
 [`mongodb`](http://mongodb.org/)                                              | `mongodb`
 [`mysql`](https://www.mysql.fr/products/community/)                           | `mysql56-community` `mysql-connectors-community` `mysql-tools-community`
 [`nginx`](http://nginx.org/)                                                  | `nginx`
+[`percona`](https://www.percona.com)                                          | `percona-release-x86_64`
 [`postgresql 9.3`](http://yum.postgresql.org/repopackages.php)                | `pgdg93`
 [`postgresql 9.4`](http://yum.postgresql.org/repopackages.php)                | `pgdg94`
 [`postgresql 9.5`](http://yum.postgresql.org/repopackages.php)                | `pgdg95`

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -128,6 +128,11 @@ repository_list:
       key: "nginx_signing.key"
       url: "http://nginx.org/packages/debian/"
       pool: "{{ ansible_distribution_release }} nginx"
+  percona-release-x86_64:
+    centos6:
+      url: "http://www.percona.com/downloads/percona-release/redhat/0.1-3/percona-release-0.1-3.noarch.rpm"
+    centos7:
+      url: "http://www.percona.com/downloads/percona-release/redhat/0.1-3/percona-release-0.1-3.noarch.rpm"
   percona:
     wheezy:
       key: "percona.key"


### PR DESCRIPTION
Percona has their own CentOS repos.
https://www.percona.com/doc/percona-xtradb-cluster/5.6/installation/yum_repo.html
