### PR TITLE
Add mesosphere repo for CentOS 6 and 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ name                                                                          | 
 [`hortonworks`](http://hortonworks.com/)                                      | `ambari-1x` `HDP-1.3.0.0` `HDP-UTILS-1.1.0.15`
 [`ius`](https://iuscommunity.org/pages/About.html)                            | `ius` `ius-testing` `ius-dev` `ius-archive`
 [`jenkins`](http://jenkins-ci.org/)                                           | `jenkins`
+[`mesophere`](https://www.mesosphere.com/)                                    | `mesosphere`
 [`mongodb`](http://mongodb.org/)                                              | `mongodb`
 [`mysql`](https://www.mysql.fr/products/community/)                           | `mysql56-community` `mysql-connectors-community` `mysql-tools-community` 
 [`nginx`](http://nginx.org/)                                                  | `nginx`
@@ -104,6 +105,7 @@ name                                                                          | 
 [`hortonworks`](http://hortonworks.com/)                                      | `ambari-1x` `HDP-1.3.0.0` `HDP-UTILS-1.1.0.15`
 [`ius`](https://iuscommunity.org/pages/About.html)                            | `ius` `ius-testing` `ius-dev` `ius-archive`
 [`jenkins`](http://jenkins-ci.org/)                                           | `jenkins`
+[`mesophere`](https://www.mesosphere.com/)                                    | `mesosphere`
 [`mongodb`](http://mongodb.org/)                                              | `mongodb`
 [`mysql`](https://www.mysql.fr/products/community/)                           | `mysql56-community` `mysql-connectors-community` `mysql-tools-community`
 [`nginx`](http://nginx.org/)                                                  | `nginx`

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -90,6 +90,11 @@ repository_list:
       key: "jenkins-ci.org.key"
       url: "http://pkg.jenkins-ci.org/debian"
       pool: "binary/"
+  mesosphere:
+    centos6:
+      url: "http://repos.mesosphere.com/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm"
+    centos7:
+      url: "http://repos.mesosphere.com/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm"
   mongodb:
     centos6:
       repo: mongodb.repo


### PR DESCRIPTION
Provides [mesos, marathon and mesosphere-zookeeper.](https://open.mesosphere.com/getting-started/install/)
